### PR TITLE
Encode cityname to prevent xss injection

### DIFF
--- a/Weather Scrapper.php
+++ b/Weather Scrapper.php
@@ -4,7 +4,7 @@ $city = '';
 $error = '';
 $forecastSite = 'https://www.weather-forecast.com/locations/{city}/forecasts/latest';
 if (array_key_exists('city', $_GET)) {
-    $city = str_replace(' ', '-', $_GET['city']);
+    $city = str_replace(' ', '-', htmlentities( $_GET['city'] ) );
     $forecastUrl = str_replace('{city}', $city, $forecastSite);
 
     $file_headers = @get_headers($forecastUrl);


### PR DESCRIPTION
Cityname variable is inserted unencoded into the dom. This enables xss injection attacks to be performed on the service.

This commit encodes the string. Since it is a small amount of text I used the more thorough but less performance friendly function.